### PR TITLE
Updates for Rev A/B relay boards

### DIFF
--- a/EyeBERT/EyeBertAutomationDev.py
+++ b/EyeBERT/EyeBertAutomationDev.py
@@ -25,6 +25,19 @@
 #   : repeat tests as needed
 #   : much better error recovery & data validation!
 
+# Hardware requirements:
+# - KC705
+# - Digital Multimeter (DMM)
+# - Relay board (Rev A)
+# - SMA adapter boards: one 45-pin Kyocera board and one 15-pin Molex board 
+# - SMA cables
+
+# Software requirements:
+# - Computer: Windows 10 PC 
+# - Languages: Python 3, TCL, Windows Batch Script 
+# - Applications: Vivado 2020.2 
+# - Code Repository: https://github.com/ku-cms/eLink_Instrumentation 
+
 # version
 version = 1.14
 
@@ -360,7 +373,7 @@ def main():
         # Confirm that user wants to continue
         user_accept = input(Fore.RED + "Would you like to continue? [y/n]: " + Fore.GREEN)
         if user_accept.lower() == "y":
-            print("Proceeding with calibration. Please connect through lines for each channel as instructed.")
+            print("Proceeding with calibration. Please connect SMA through lines for each channel as instructed.")
         else:
             print("Exiting...")
             print(Fore.RED + "Terminating code 3: exit based on user input.")
@@ -381,8 +394,8 @@ def main():
             txpath = b"tx " + bytes(cable_mapping[key]['tx'], 'utf-8')
             rxpath = b"rx " + bytes(cable_mapping[key]['rx'], 'utf-8')
 
-            # pause for user to connect through lines (P to P and N to N) for channel
-            print(Fore.RED + f"Please connect through lines (P to P and N to N) for channel {key}: txpath = {txpath.decode()} and rxpath = {rxpath.decode()}." + Fore.GREEN)
+            # pause for user to connect SMA through lines (P to P and N to N) for channel
+            print(Fore.RED + f"Please connect SMA through lines (P to P and N to N) for channel {key}: txpath = {txpath.decode()} and rxpath = {rxpath.decode()}." + Fore.GREEN)
             user_ready = input(Fore.RED + f"Press enter when ready. " + Fore.GREEN)
 
             # take measurements; do not subtract anything

--- a/EyeBERT/EyeBertAutomationDev.py
+++ b/EyeBERT/EyeBertAutomationDev.py
@@ -26,7 +26,7 @@
 #   : much better error recovery & data validation!
 
 # version
-version = 1.13
+version = 1.14
 
 from template_analysis_windows import EyeBERTFile, Reference
 from colorama import Fore, Back, Style, init
@@ -51,6 +51,19 @@ from pathvalidate import is_valid_filename
 import eyebertserial
 import dmmserial
 import json
+
+# get adapter board channel
+def getAdapterBoardChannel(cable_type, channel):
+    channel_map = {
+                "cmd" : "cmd", 
+                "d2" : "d1",
+                "d1" : "d2",
+                "d0" : "d3"
+    }
+    if cable_type == "2p3" or cable_type == "1p3":
+        return channel_map[channel]
+    else:
+        return channel 
 
 # get bad 4-point DC channels
 def GetBadDCChannels(measurement_data):
@@ -424,11 +437,12 @@ def main():
                 continue
             # otherwise, we assume that the key is the channel
             else:
+                key_adapter_board = getAdapterBoardChannel(cable_type, key)
                 channel = str(key)
             
             # get calibration data for channel (for both P and N lines)
-            pos_path = calibration_data[key + "_p"]
-            neg_path = calibration_data[key + "_n"]
+            pos_path = calibration_data[key_adapter_board + "_p"]
+            neg_path = calibration_data[key_adapter_board + "_n"]
             
             # get TX and RX paths from cable mapping
             txpath = b"tx " + bytes(cable_mapping[key]['tx'], 'utf-8')
@@ -612,7 +626,7 @@ def main():
             # create custom "source eye_and_save.tcl" with the cable name & path included
             eye_and_save = "C:/Users/Public/Documents/cable_tests/eye_and_save.tcl"
             with open (eye_and_save, 'w') as f :
-                f.write("source create_scan_0.tcl\r\n")
+                f.write("source create_scan_0_RevA.tcl\r\n")
                 f.write(f"set_property DESCRIPTION {test_name} [get_hw_sio_scans SCAN_0]\r\n")
                 f.write("run_hw_sio_scan [lindex [get_hw_sio_scans {SCAN_0}] 0]\r\n")
                 f.write("wait_on_hw_sio_scan [lindex [get_hw_sio_scans {SCAN_0}] 0]\r\n")

--- a/EyeBERT/EyeBertAutomationRev2.py
+++ b/EyeBERT/EyeBertAutomationRev2.py
@@ -25,7 +25,18 @@
 #   : repeat tests as needed
 #   : much better error recovery & data validation!
 
-# Updated for the Rev B relay board
+# Hardware requirements:
+# - KC705
+# - Digital Multimeter (DMM)
+# - Relay board (Rev B)
+# - SMA adapter boards: one 45-pin Kyocera board and three 15-pin Molex boards 
+# - SMA cables
+
+# Software requirements:
+# - Computer: Windows 10 PC 
+# - Languages: Python 3, TCL, Windows Batch Script 
+# - Applications: Vivado 2020.2 
+# - Code Repository: https://github.com/ku-cms/eLink_Instrumentation 
 
 # version
 version = 2.2
@@ -54,8 +65,7 @@ import eyebertserial
 import dmmserial
 import json
 
-# FIXME: Create new Rev 2 DC calibration files for Rev B relay board
-# get 4-point DC cabliration file based on cable type
+# get 4-point DC calibration file based on cable type
 def GetDCCalibrationFile(cable_type):
     if cable_type in ["1", "5K", "5K2"]:
         return "4_point_DC_Calibration_v1.json"
@@ -207,22 +217,10 @@ def main():
         "2p3"   : mapping_type2p3,
         "1p3"   : mapping_type1p3
     }
-    # FIXME: Update for Rev B relay board: entries should include both branch and channel (e.g. A_cmd_p)
-
-    # channels for Rev A relay board
-    # cable channels for supported e-link types
-    # cable_channels = {
-    #     "1"     : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d1_p", "d1_n", "d2_p", "d2_n", "d3_p", "d3_n"],
-    #     "5K"    : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d1_p", "d1_n", "d2_p", "d2_n", "d3_p", "d3_n"],
-    #     "5K2"   : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d1_p", "d1_n", "d2_p", "d2_n", "d3_p", "d3_n"],
-    #     "3p2"   : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d2_p", "d2_n"],
-    #     "2p2"   : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d2_p", "d2_n"],
-    #     "2p3"   : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d1_p", "d1_n", "d2_p", "d2_n"],
-    #     "1p3"   : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d1_p", "d1_n", "d2_p", "d2_n"]
-    # }
-
-    # channels for Rev B relay board
-    # entries should include both branch and channel (e.g. A_cmd_p)
+    
+    # channels for Rev B relay board for supported e-link types
+    # - for e-links without branches, entries should include channel and sign (e.g. cmd_p)
+    # - for e-links with branches, entries should include branch, channel, and sign (e.g. A_cmd_p)
     cable_channels = {
         "1"     : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d1_p", "d1_n", "d2_p", "d2_n", "d3_p", "d3_n"],
         "5K"    : ["cmd_p", "cmd_n", "d0_p", "d0_n", "d1_p", "d1_n", "d2_p", "d2_n", "d3_p", "d3_n"],
@@ -389,21 +387,12 @@ def main():
         while accept not in valid_inputs:
             accept = input(f"The input '{accept}' is not vaild. Do you want to proceed (y/n): ").lower()
         if accept == "y":
-            print("Proceeding with calibration. Please connect through lines for each channel as instructed.")
+            print("Proceeding with calibration. Please connect SMA through lines for each channel as instructed.")
         if accept == "n":
             print("Exiting...")
             print(Fore.RED + "Terminating code 3: exit based on user input.")
             sys.exit(3)
-        
-        # Confirm that user wants to continue
-        # user_accept = input(Fore.RED + "Would you like to continue? [y/n]: " + Fore.GREEN)
-        # if user_accept.lower() == "y":
-        #     print("Proceeding with calibration. Please connect through lines for each channel as instructed.")
-        # else:
-        #     print("Exiting...")
-        #     print(Fore.RED + "Terminating code 3: exit based on user input.")
-        #     sys.exit(3)
-        
+                
         print("Measured calibration values (ohms):")
 
         # Loop over channels
@@ -418,11 +407,9 @@ def main():
             # get TX and RX paths from cable mapping
             txpath = b"tx " + bytes(cable_mapping[key]['tx'], 'utf-8')
             rxpath = b"rx " + bytes(cable_mapping[key]['rx'], 'utf-8')
-
-            # FIXME: verify if we should use P and N according to e-link mapping, or always "P to P" and "N to N" according to relay board labels
-            # pause for user to connect through lines (P and N according to e-link mapping) for channel
-            print(Fore.RED + f"Please connect through lines (P and N according to e-link mapping) for channel {key}: txpath = {txpath.decode()} and rxpath = {rxpath.decode()}." + Fore.GREEN)
             
+            # pause for user to connect SMA through lines (P to P and N to N) for channel
+            print(Fore.RED + f"Please connect SMA through lines (P to P and N to N) for channel {key}: txpath = {txpath.decode()} and rxpath = {rxpath.decode()}." + Fore.GREEN)
             user_ready = input(Fore.RED + f"Press enter when ready. " + Fore.GREEN)
 
             # take measurements; do not subtract anything

--- a/EyeBERT/EyeBertAutomationRev2.py
+++ b/EyeBERT/EyeBertAutomationRev2.py
@@ -60,9 +60,9 @@ def GetDCCalibrationFile(cable_type):
     if cable_type in ["1", "5K", "5K2"]:
         return "4_point_DC_Calibration_v1.json"
     elif cable_type in ["3p2", "2p2"]:
-        return "4_point_DC_CalibrationRev2_Type3p2_v0.json"
+        return "4_point_DC_CalibrationRev2_Type3p2_v2.json"
     elif cable_type in ["2p3", "1p3"]:
-        return "4_point_DC_CalibrationRev2_Type2p3_v0.json"
+        return "4_point_DC_CalibrationRev2_Type2p3_v2.json"
     else:
         print(Fore.RED + f"ERROR: There is no calibration file available for cable type {cable_type}." + Fore.GREEN)
         return ""
@@ -96,9 +96,9 @@ def main():
     # parameters
     # TODO: let user specify parameters for what test(s) to run
     verbose                     = False
-    RUN_4PT_DC_RES_CALIBRATION  = True
-    RUN_4PT_DC_RES              = False
-    RUN_EYE_BERT_AREA           = False
+    RUN_4PT_DC_RES_CALIBRATION  = False
+    RUN_4PT_DC_RES              = True
+    RUN_EYE_BERT_AREA           = True
     pygui.PAUSE = 0.5
     
     # dictionaries to save results
@@ -716,7 +716,7 @@ def main():
             # create custom "source eye_and_save.tcl" with the cable name & path included
             eye_and_save = "C:/Users/Public/Documents/cable_tests/eye_and_save.tcl"
             with open (eye_and_save, 'w') as f :
-                f.write("source create_scan_0.tcl\r\n")
+                f.write("source create_scan_0_RevB.tcl\r\n")
                 f.write(f"set_property DESCRIPTION {test_name} [get_hw_sio_scans SCAN_0]\r\n")
                 f.write("run_hw_sio_scan [lindex [get_hw_sio_scans {SCAN_0}] 0]\r\n")
                 f.write("wait_on_hw_sio_scan [lindex [get_hw_sio_scans {SCAN_0}] 0]\r\n")

--- a/EyeBERT/create_scan_0_RevA.tcl
+++ b/EyeBERT/create_scan_0_RevA.tcl
@@ -12,11 +12,6 @@ remove_hw_sio_scan [get_hw_sio_scans {SCAN_0}]
 set_property TXDIFFSWING {1018 mV (1100)} [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
 commit_hw_sio -non_blocking [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
 
-# Setting for Rev B relay board
-# set TXDIFFSWING to "1119 mV (1111)"
-#set_property TXDIFFSWING {1119 mV (1111)} [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
-#commit_hw_sio -non_blocking [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
-
 # Set TX Pre-Cursor setting:
 
 # Set TX Pre-Cursor to "0.00 dB (00000)"

--- a/EyeBERT/create_scan_0_RevB.tcl
+++ b/EyeBERT/create_scan_0_RevB.tcl
@@ -7,15 +7,10 @@ remove_hw_sio_scan [get_hw_sio_scans {SCAN_0}]
 #set_property TXDIFFSWING {741 mV (0111)} [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
 #commit_hw_sio -non_blocking [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
 
-# Setting for Rev A relay board
-# set TXDIFFSWING to "1018 mV (1100)"
-set_property TXDIFFSWING {1018 mV (1100)} [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
-commit_hw_sio -non_blocking [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
-
 # Setting for Rev B relay board
 # set TXDIFFSWING to "1119 mV (1111)"
-#set_property TXDIFFSWING {1119 mV (1111)} [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
-#commit_hw_sio -non_blocking [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
+set_property TXDIFFSWING {1119 mV (1111)} [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
+commit_hw_sio -non_blocking [get_hw_sio_links {localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX->localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/RX}]
 
 # Set TX Pre-Cursor setting:
 

--- a/EyeBERT/set_tx_polarity_invert.tcl
+++ b/EyeBERT/set_tx_polarity_invert.tcl
@@ -1,0 +1,2 @@
+set_property PORT.TXPOLARITY 1 [get_hw_sio_txs localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX]
+commit_hw_sio [get_hw_sio_txs localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX]

--- a/EyeBERT/set_tx_polarity_normal.tcl
+++ b/EyeBERT/set_tx_polarity_normal.tcl
@@ -1,0 +1,2 @@
+set_property PORT.TXPOLARITY 0 [get_hw_sio_txs localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX]
+commit_hw_sio [get_hw_sio_txs localhost:3121/xilinx_tcf/Digilent/210203AE483DA/0_1_0/IBERT/Quad_117/MGT_X0Y8/TX]

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ mkdir -p data
 mkdir -p plots
 cd ..
 ```
+For more installation and setup instructions,
+refer to the subdirectory for the test you want to use (see links in the Usage section).
 
 ## Usage
 
-- Eye BERT diagrams: the required files and instructions to measure e-link Eye BERT diagrams are [here](https://github.com/ku-cms/eLink_Instrumentation/tree/main/EyeBERT).
+- Automated EyeBERT and 4-point DC resistance: the required files and instructions are [here](https://github.com/ku-cms/eLink_Instrumentation/tree/main/EyeBERT).
 - Oscilloscope eye diagrams: the data processing scripts to study e-link eye diagrams are [here](https://github.com/ku-cms/eLink_Instrumentation/tree/main/EyeDiagrams).
 - VNA impedance: the data processing scripts to study e-link impedance are [here](https://github.com/ku-cms/eLink_Instrumentation/tree/main/VNA).
 - Aurora bitstream: the files used to emulate the RD53A bitstream in order to test the Ernie board are [here](https://github.com/ku-cms/eLink_Instrumentation/tree/main/Aurora_bitstream).


### PR DESCRIPTION
Updates for Rev A relay board:
- Add hardware and software requirements
- Use dedicated create scan TCL file (create_scan_0_RevA.tcl) to mitigate issues in switching relay boards
- Fix applied 4-point DC calibrations for Type 2.3 and 1.3 e-links; resolves this issue: https://github.com/ku-cms/eLink_Instrumentation/issues/53

Updates for Rev B relay board:
- Add hardware and software requirements
- Use dedicated create scan TCL file (create_scan_0_RevB.tcl) to mitigate issues in switching relay boards
- Update 4-point DC calibration: use v2 files
- During 4-point DC calibration, request "SMA through lines (P to P and N to N)," which Nora verified
- Remove old commented code