### PR TITLE
Wire Length Calculator

### DIFF
--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -1,10 +1,27 @@
 # calc_length.py
-
+#
+# Developed by the KU CMS group.
+#
+# ---------------------- #
+# Wire Length Calculator
+# Author: Caleb Smith
+# ---------------------- #
+#
+# Computes the total wire length for 1 e-link and n e-links based on user input.
+#
+# The user must input the following information:
+# - e-link wiring type
+# - e-link length type
+# - loss per twisted pair (mm)
+# - number of e-links
+# - FIXME: current wire log (ft)
+#
 # TODO:
 # - Ask user for current wire log value in feet (remaining length of wire in spool)
 # - Print the new wire log value in feet (after subtracting used wire)
 # - Create LengthCalculator class
-
+# - Print results in mm and ft
+#
 # DONE:
 # - Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
 # - Process input length type to support these formats: R1_G1, r1_g1, R1 G1, and r1 g1.

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -11,14 +11,37 @@ import tools
 
 # cable branches based on wiring type
 cable_branches = {
-    "3p2" : ["A", "B", "C"],
-    "2p2" : ["A", "C"],
-    "2p3" : ["A", "B"],
-    "1p3" : ["A"]
+    "3.2" : ["A", "B", "C"],
+    "2.2" : ["A", "C"],
+    "2.3" : ["A", "B"],
+    "1.3" : ["A"]
+}
+
+# cable lengths from Design B (Axel Filenius, March 1, 2024)
+cable_lengths = {
+    # Ring 1 (R1)
+    "2.3 R1_G1" : {"A" : 280, "B" : 280},
+    "2.3 R1_G2" : {"A" : 275, "B" : 330},
+    "1.3 R1_G3" : {"A" : 390},
+    # Ring 2 (R2)
+    "2.3 R2_G1" : {"A" : 200, "B" : 240},
+    "2.3 R2_G2" : {"A" : 275, "B" : 330},
+    "2.3 R2_G3" : {"A" : 275, "B" : 330},
+    "2.3 R2_G4" : {"A" : 337, "B" : 377},
+    # Ring 3 (R3)
+    "3.2 R3_G1" : {"A" : 200, "B" : 215, "C": 310},
+    "3.2 R3_G2" : {"A" : 365, "B" : 435, "C": 510},
+    # Ring 4 (R4)
+    "3.2 R4_G1" : {"A" : 190, "B" : 200, "C": 235},
+    "3.2 R4_G2" : {"A" : 230, "B" : 275, "C": 315},
+    "2.2 R4_G3" : {"A" : 360, "C" : 405},
 }
 
 # supported wiring types
 wiring_types = list(cable_branches.keys())
+
+# supported full types (wiring + length)
+full_types = list(cable_lengths.keys())
 
 # calculate wire length for one e-link
 def CalcWireLengthElink(wiring_type, length_type, loss):
@@ -54,7 +77,7 @@ def run():
     # Idea:
     # support both formats for type: 3.2 and 3p2
     # convert on format to the other using replace()
-    
+
     print("-------------------------------------")
     print(f" - wiring_type: {wiring_type}")
     print(f" - length_type: {length_type}")

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -1,8 +1,27 @@
 # calc_length.py
 
+# TODO:
+# - Require valid user inputs
+# - Convert user inputs to int when applicable
+# - Create class
+
+# DONE:
+
+# cable branches based on cable type
+cable_branches = {
+    "3p2" : ["A", "B", "C"],
+    "2p2" : ["A", "C"],
+    "2p3" : ["A", "B"],
+    "1p3" : ["A"]
+}
+
+# supported cable types
+cable_types = list(cable_branches.keys())
+
 # Calculate length
 def CalculateLength(wiring_type, length_type, n_elinks, loss):
-    pass
+    branches = cable_branches[wiring_type]
+    print(f"branches: {branches}")
 
 def run():
     print("Calculating twisted pair wire lengths.")
@@ -13,6 +32,10 @@ def run():
     length_type = input("Enter e-link length type: ")
     n_elinks    = input("Enter number of e-links: ")
     loss        = input("Enter loss per twisted pair (mm): ")
+
+    # Idea:
+    # support both formats for type: 3.2 and 3p2
+    # convert on format to the other using replace()
     
     print("--------------------------------------")
     print(f"wiring_type: {wiring_type}")

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -7,7 +7,9 @@
 
 # DONE:
 
-# cable branches based on cable type
+import tools
+
+# cable branches based on wiring type
 cable_branches = {
     "3p2" : ["A", "B", "C"],
     "2p2" : ["A", "C"],
@@ -15,12 +17,19 @@ cable_branches = {
     "1p3" : ["A"]
 }
 
-# supported cable types
-cable_types = list(cable_branches.keys())
+# supported wiring types
+wiring_types = list(cable_branches.keys())
 
 # Calculate length
 def CalculateLength(wiring_type, length_type, n_elinks, loss):
-    branches = cable_branches[wiring_type]
+    branches = []
+    wiring_type_is_valid = tools.is_valid_cable_type(wiring_types, wiring_type)
+    if wiring_type_is_valid:
+        branches = cable_branches[wiring_type]
+    else:
+        print(f"ERROR: {wiring_type} is not a valid wiring type.")
+        print(f"Please enter a valid wiring type: {wiring_types}")
+        return
     print(f"branches: {branches}")
 
 def run():
@@ -43,7 +52,9 @@ def run():
     print(f"n_elinks: {n_elinks}")
     print(f"loss: {loss} mm")
 
-    # Calculate length
+    # Calculate length;
+    # may split into two steps: 1 e-link vs. n e-links
+    # so that we can print out both...
     CalculateLength(wiring_type, length_type, n_elinks, loss)
 
 def main():

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -20,8 +20,9 @@ cable_branches = {
 # supported wiring types
 wiring_types = list(cable_branches.keys())
 
-# Calculate length
-def CalculateLength(wiring_type, length_type, n_elinks, loss):
+# calculate wire length for one e-link
+def CalcWireLengthElink(wiring_type, length_type, loss):
+    wire_length_elink = -1
     branches = []
     wiring_type_is_valid = tools.is_valid_cable_type(wiring_types, wiring_type)
     if wiring_type_is_valid:
@@ -29,33 +30,54 @@ def CalculateLength(wiring_type, length_type, n_elinks, loss):
     else:
         print(f"ERROR: {wiring_type} is not a valid wiring type.")
         print(f"Please enter a valid wiring type: {wiring_types}")
-        return
+        return wire_length_elink
     print(f"branches: {branches}")
+    return wire_length_elink
+
+# calculate wire length for a batch of n e-links
+def CalcWireLengthBatch(n_elinks, wire_length_elink):
+    wire_length_batch = n_elinks * wire_length_elink
+    return wire_length_batch
 
 def run():
-    print("Calculating twisted pair wire lengths.")
-    print("--------------------------------------")
+    print("Calculating twisted pair wire length.")
+    print("-------------------------------------")
     
     # User input
     wiring_type = input("Enter e-link wiring type: ")
     length_type = input("Enter e-link length type: ")
-    n_elinks    = input("Enter number of e-links: ")
     loss        = input("Enter loss per twisted pair (mm): ")
+    n_elinks    = input("Enter number of e-links: ")
+
+    # FIXME: Convert user inputs to int when applicable
 
     # Idea:
     # support both formats for type: 3.2 and 3p2
     # convert on format to the other using replace()
     
-    print("--------------------------------------")
-    print(f"wiring_type: {wiring_type}")
-    print(f"length_type: {length_type}")
-    print(f"n_elinks: {n_elinks}")
-    print(f"loss: {loss} mm")
+    print("-------------------------------------")
+    print(f" - wiring_type: {wiring_type}")
+    print(f" - length_type: {length_type}")
+    print(f" - loss: {loss} mm")
+    print(f" - n_elinks: {n_elinks}")
+    print("-------------------------------------")
 
     # Calculate length;
     # may split into two steps: 1 e-link vs. n e-links
     # so that we can print out both...
-    CalculateLength(wiring_type, length_type, n_elinks, loss)
+
+    # calculate wire length for one e-link
+    wire_length_elink = CalcWireLengthElink(wiring_type, length_type, loss)
+
+    # if length < 0 (invalid), return
+    if wire_length_elink < 0:
+        return
+
+    # calculate wire length for a batch of n e-links
+    wire_length_batch = CalcWireLengthBatch(n_elinks, wire_length_elink)
+
+    print(f"wire_length_elink: {wire_length_elink}")
+    print(f"wire_length_batch: {wire_length_batch}")
 
 def main():
     run()

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -1,0 +1,31 @@
+# calc_length.py
+
+# Calculate length
+def CalculateLength(wiring_type, length_type, n_elinks, loss):
+    pass
+
+def run():
+    print("Calculating twisted pair wire lengths.")
+    print("--------------------------------------")
+    
+    # User input
+    wiring_type = input("Enter e-link wiring type: ")
+    length_type = input("Enter e-link length type: ")
+    n_elinks    = input("Enter number of e-links: ")
+    loss        = input("Enter loss per twisted pair (mm): ")
+    
+    print("--------------------------------------")
+    print(f"wiring_type: {wiring_type}")
+    print(f"length_type: {length_type}")
+    print(f"n_elinks: {n_elinks}")
+    print(f"loss: {loss} mm")
+
+    # Calculate length
+    CalculateLength(wiring_type, length_type, n_elinks, loss)
+
+def main():
+    run()
+
+if __name__ == "__main__":
+    run()
+

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -48,7 +48,7 @@ full_types = list(cable_lengths.keys())
 def CalcWireLengthElink(wiring_type, length_type, loss):
     wire_length_elink = -1
     branches = []
-    wiring_type_is_valid = script_tools.is_valid_cable_type(wiring_types, wiring_type)
+    wiring_type_is_valid = script_tools.group_contains_element(wiring_types, wiring_type)
     if wiring_type_is_valid:
         branches = cable_branches[wiring_type]
     else:

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -65,14 +65,15 @@ def CalcWireLengthBatch(n_elinks, wire_length_elink):
     return wire_length_batch
 
 def run():
-    print("Calculating twisted pair wire length.")
+    print("-------------------------------------")
+    print(Fore.GREEN + "Calculating twisted pair wire length." + Fore.RESET)
     print("-------------------------------------")
     
     # User input
-    wiring_type = input("Enter e-link wiring type: ")
-    length_type = input("Enter e-link length type: ")
-    loss        = input("Enter loss per twisted pair (mm): ")
-    n_elinks    = input("Enter number of e-links: ")
+    wiring_type = input(Fore.GREEN + "Enter e-link wiring type: " + Fore.RESET)
+    length_type = input(Fore.GREEN + "Enter e-link length type: " + Fore.RESET)
+    loss        = input(Fore.GREEN + "Enter loss per twisted pair (mm): " + Fore.RESET)
+    n_elinks    = input(Fore.GREEN + "Enter number of e-links: " + Fore.RESET)
 
     # FIXME: Convert user inputs to int when applicable
 

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -19,14 +19,14 @@
 # TODO:
 # - Ask user for current wire log value in feet (remaining length of wire in spool)
 # - Print the new wire log value in feet (after subtracting used wire)
-# - Create LengthCalculator class
-# - Print results in mm and ft
+# - Create LengthCalculator class in a different file
 #
 # DONE:
 # - Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
 # - Process input length type to support these formats: R1_G1, r1_g1, R1 G1, and r1 g1.
 # - Convert user inputs to int when applicable
 # - Require valid user inputs
+# - Print results in mm and ft
 
 from colorama import Fore, Back, Style, init
 import script_tools
@@ -50,7 +50,7 @@ cable_channels_per_branch = {
     "1.3" : 4
 }
 
-# cable lengths from Design B (Axel Filenius, March 1, 2024)
+# cable lengths (mm) from Design B (Axel Filenius, March 1, 2024)
 cable_lengths = {
     # Ring 1 (R1)
     "2.3 R1_G1" : {"A" : 280, "B" : 280},
@@ -162,17 +162,20 @@ def run():
     # so that we can print out both.
 
     # calculate wire length for one e-link
-    wire_length_elink = CalcWireLengthElink(wiring_type, length_type, loss)
+    wire_length_elink_mm = CalcWireLengthElink(wiring_type, length_type, loss)
+    wire_length_elink_ft = script_tools.convert_mm_to_ft(wire_length_elink_mm)
 
     # if length < 0 (invalid), return
-    if wire_length_elink < 0:
+    if wire_length_elink_mm < 0:
         return
 
     # calculate wire length for a batch of n e-links
-    wire_length_batch = CalcWireLengthBatch(n_elinks, wire_length_elink)
+    wire_length_batch_mm = CalcWireLengthBatch(n_elinks, wire_length_elink_mm)
+    wire_length_batch_ft = script_tools.convert_mm_to_ft(wire_length_batch_mm)
 
-    print(f"wire_length_elink: {wire_length_elink}")
-    print(f"wire_length_batch: {wire_length_batch}")
+    # FIXME: print old and new wire log values
+    print(f"wire length for 1 e-link: {wire_length_elink_mm} mm = {wire_length_elink_ft:.1f} ft")
+    print(f"wire length for {n_elinks} e-links: {wire_length_batch_mm} mm = {wire_length_batch_ft:.1f} ft")
 
 def main():
     run()

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -8,18 +8,17 @@
 # ---------------------- #
 #
 # Computes the total wire length for 1 e-link and n e-links based on user input.
+# Also computes updated wire log.
 #
 # The user must input the following information:
 # - e-link wiring type
 # - e-link length type
 # - loss per twisted pair (mm)
 # - number of e-links
-# - FIXME: current wire log (ft)
+# - previous wire log (ft)
 #
 # TODO:
-# - Ask user for current wire log value in feet (remaining length of wire in spool)
-# - Print the new wire log value in feet (after subtracting used wire)
-# - Create LengthCalculator class in a different file
+# - Create LengthCalculator or WireLengthCalculator class in a different file
 #
 # DONE:
 # - Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
@@ -27,6 +26,8 @@
 # - Convert user inputs to int when applicable
 # - Require valid user inputs
 # - Print results in mm and ft
+# - Ask user for previous wire log value in feet (remaining length of wire in spool)
+# - Print the new wire log value in feet (after subtracting used wire)
 
 from colorama import Fore, Back, Style, init
 import script_tools
@@ -139,10 +140,11 @@ def run():
     script_tools.printLine(line_length)
     
     # User input
-    wiring_type = input(Fore.GREEN + "Enter e-link wiring type: " + Fore.RESET)
-    length_type = input(Fore.GREEN + "Enter e-link length type: " + Fore.RESET)
-    loss        = int(input(Fore.GREEN + "Enter loss per twisted pair (mm): " + Fore.RESET))
-    n_elinks    = int(input(Fore.GREEN + "Enter number of e-links: " + Fore.RESET))
+    wiring_type     = input(Fore.GREEN + "Enter e-link wiring type: " + Fore.RESET)
+    length_type     = input(Fore.GREEN + "Enter e-link length type: " + Fore.RESET)
+    loss            = float(input(Fore.GREEN + "Enter loss per twisted pair (mm): " + Fore.RESET))
+    n_elinks        = int(input(Fore.GREEN + "Enter number of e-links: " + Fore.RESET))
+    prev_wire_log   = float(input(Fore.GREEN + "Enter previous wire log entry (ft): " + Fore.RESET))
 
     # format wiring type
     wiring_type = script_tools.formatWiringType(wiring_type)
@@ -155,6 +157,7 @@ def run():
     print(f" - length_type: {length_type}")
     print(f" - loss: {loss} mm")
     print(f" - n_elinks: {n_elinks}")
+    print(f" - prev_wire_log: {prev_wire_log} ft")
     script_tools.printLine(line_length)
 
     # Calculate wire length:
@@ -173,9 +176,16 @@ def run():
     wire_length_batch_mm = CalcWireLengthBatch(n_elinks, wire_length_elink_mm)
     wire_length_batch_ft = script_tools.convert_mm_to_ft(wire_length_batch_mm)
 
-    # FIXME: print old and new wire log values
-    print(f"wire length for 1 e-link: {wire_length_elink_mm} mm = {wire_length_elink_ft:.1f} ft")
-    print(f"wire length for {n_elinks} e-links: {wire_length_batch_mm} mm = {wire_length_batch_ft:.1f} ft")
+    # calculate new wire log
+    new_wire_log = prev_wire_log - wire_length_batch_ft
+
+    print(Fore.GREEN + f"Wire length for 1 e-link: " + Fore.RESET)
+    print(f"\t{wire_length_elink_mm:.1f} mm = {wire_length_elink_ft:.1f} ft")
+    print(Fore.GREEN + f"Wire length for {n_elinks} e-links: " + Fore.RESET)
+    print(f"\t{wire_length_batch_mm:.1f} mm = {wire_length_batch_ft:.1f} ft")
+    print(Fore.GREEN + f"New wire log entry: " + Fore.RESET)
+    print(f"\t{prev_wire_log:.1f} ft - {wire_length_batch_ft:.1f} ft = {new_wire_log:.1f} ft")
+    script_tools.printLine(line_length)
 
 def main():
     run()

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -7,7 +7,8 @@
 
 # DONE:
 
-import tools
+from colorama import Fore, Back, Style, init
+import script_tools
 
 # cable branches based on wiring type
 cable_branches = {
@@ -47,12 +48,12 @@ full_types = list(cable_lengths.keys())
 def CalcWireLengthElink(wiring_type, length_type, loss):
     wire_length_elink = -1
     branches = []
-    wiring_type_is_valid = tools.is_valid_cable_type(wiring_types, wiring_type)
+    wiring_type_is_valid = script_tools.is_valid_cable_type(wiring_types, wiring_type)
     if wiring_type_is_valid:
         branches = cable_branches[wiring_type]
     else:
-        print(f"ERROR: {wiring_type} is not a valid wiring type.")
-        print(f"Please enter a valid wiring type: {wiring_types}")
+        print(Fore.RED + f"ERROR: {wiring_type} is not a valid wiring type." + Fore.RESET)
+        print(Fore.RED + f"Please enter a valid wiring type: {wiring_types}" + Fore.RESET)
         return wire_length_elink
     print(f"branches: {branches}")
     return wire_length_elink

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -49,14 +49,24 @@ full_types = list(cable_lengths.keys())
 def CalcWireLengthElink(wiring_type, length_type, loss):
     wire_length_elink = -1
     branches = []
+    full_type = ""
+    
+    # check if wiring type is valid
     wiring_type_is_valid = script_tools.group_contains_element(wiring_types, wiring_type)
     if wiring_type_is_valid:
+        # assign branches
         branches = cable_branches[wiring_type]
     else:
+        # print error messages and return
         print(Fore.RED + f"ERROR: {wiring_type} is not a valid wiring type." + Fore.RESET)
         print(Fore.RED + f"Please enter a valid wiring type: {wiring_types}" + Fore.RESET)
         return wire_length_elink
     print(f"branches: {branches}")
+    
+    # check if full type (wiring + length) is valid
+    full_type = "{0} {1}".format(wiring_type, length_type)
+    print(f"full_type: {full_type}")
+    
     return wire_length_elink
 
 # calculate wire length for a batch of n e-links
@@ -77,11 +87,11 @@ def run():
 
     # FIXME: Convert user inputs to int when applicable
 
-    # Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
-    # - Convert to lowercase.
-    # - Replace "p" with ".".
-    wiring_type = wiring_type.lower()
-    wiring_type = wiring_type.replace("p", ".")
+    # format wiring type
+    wiring_type = script_tools.formatWiringType(wiring_type)
+
+    # format length type
+    length_type = script_tools.formatLengthType(length_type)
 
     print("-------------------------------------")
     print(f" - wiring_type: {wiring_type}")

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -6,6 +6,7 @@
 # - Create class
 
 # DONE:
+# - Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
 
 from colorama import Fore, Back, Style, init
 import script_tools
@@ -75,9 +76,11 @@ def run():
 
     # FIXME: Convert user inputs to int when applicable
 
-    # Idea:
-    # support both formats for type: 3.2 and 3p2
-    # convert on format to the other using replace()
+    # Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
+    # - Convert to lowercase.
+    # - Replace "p" with ".".
+    wiring_type = wiring_type.lower()
+    wiring_type = wiring_type.replace("p", ".")
 
     print("-------------------------------------")
     print(f" - wiring_type: {wiring_type}")
@@ -86,9 +89,9 @@ def run():
     print(f" - n_elinks: {n_elinks}")
     print("-------------------------------------")
 
-    # Calculate length;
-    # may split into two steps: 1 e-link vs. n e-links
-    # so that we can print out both...
+    # Calculate wire length:
+    # Split into two steps (1 e-link and n e-links)
+    # so that we can print out both.
 
     # calculate wire length for one e-link
     wire_length_elink = CalcWireLengthElink(wiring_type, length_type, loss)

--- a/scripts/calc_length.py
+++ b/scripts/calc_length.py
@@ -11,6 +11,9 @@
 from colorama import Fore, Back, Style, init
 import script_tools
 
+# specify length of line for printing
+line_length = 50
+
 # cable branches based on wiring type
 cable_branches = {
     "3.2" : ["A", "B", "C"],
@@ -48,8 +51,9 @@ full_types = list(cable_lengths.keys())
 # calculate wire length for one e-link
 def CalcWireLengthElink(wiring_type, length_type, loss):
     wire_length_elink = -1
-    branches = []
     full_type = ""
+    branches = []
+    branch_lengths = {}
     
     # check if wiring type is valid
     wiring_type_is_valid = script_tools.group_contains_element(wiring_types, wiring_type)
@@ -59,13 +63,29 @@ def CalcWireLengthElink(wiring_type, length_type, loss):
     else:
         # print error messages and return
         print(Fore.RED + f"ERROR: {wiring_type} is not a valid wiring type." + Fore.RESET)
-        print(Fore.RED + f"Please enter a valid wiring type: {wiring_types}" + Fore.RESET)
+        print(Fore.RED + f"Please enter a valid wiring type from this list:" + Fore.RESET)
+        print(Fore.RED + f"{wiring_types}" + Fore.RESET)
         return wire_length_elink
-    print(f"branches: {branches}")
+    
+    # get full type (wiring + length)
+    full_type = "{0} {1}".format(wiring_type, length_type)
     
     # check if full type (wiring + length) is valid
-    full_type = "{0} {1}".format(wiring_type, length_type)
-    print(f"full_type: {full_type}")
+    full_type_is_valid = script_tools.group_contains_element(full_types, full_type)
+    if full_type_is_valid:
+        # assign branch lengths
+        branch_lengths = cable_lengths[full_type]
+    else:
+        # print error messages and return
+        print(Fore.RED + f"ERROR: {full_type} is not a valid e-link type (defined by wiring and length)." + Fore.RESET)
+        print(Fore.RED + f"Please enter a valid combination of e-link wiring and length types from this list:" + Fore.RESET)
+        print(Fore.RED + f"{full_types}" + Fore.RESET)
+        return wire_length_elink
+    
+    print(f" - full_type: {full_type}")
+    print(f" - branches: {branches}")
+    print(f" - branch_lengths: {branch_lengths}")
+    script_tools.printLine(line_length)
     
     return wire_length_elink
 
@@ -75,9 +95,9 @@ def CalcWireLengthBatch(n_elinks, wire_length_elink):
     return wire_length_batch
 
 def run():
-    print("-------------------------------------")
+    script_tools.printLine(line_length)
     print(Fore.GREEN + "Calculating twisted pair wire length." + Fore.RESET)
-    print("-------------------------------------")
+    script_tools.printLine(line_length)
     
     # User input
     wiring_type = input(Fore.GREEN + "Enter e-link wiring type: " + Fore.RESET)
@@ -93,12 +113,12 @@ def run():
     # format length type
     length_type = script_tools.formatLengthType(length_type)
 
-    print("-------------------------------------")
+    script_tools.printLine(line_length)
     print(f" - wiring_type: {wiring_type}")
     print(f" - length_type: {length_type}")
     print(f" - loss: {loss} mm")
     print(f" - n_elinks: {n_elinks}")
-    print("-------------------------------------")
+    script_tools.printLine(line_length)
 
     # Calculate wire length:
     # Split into two steps (1 e-link and n e-links)

--- a/scripts/script_tools.py
+++ b/scripts/script_tools.py
@@ -1,15 +1,14 @@
 # script_tools.py
 
-# This is a place for utility functions (tools).
+# This is a place for utility functions (tools) for scripts.
 
 # To use these functions in another file, add this import statement:
-# import tools
+# import script_tools
 
 # Then, call functions as needed, for example:
-# tools.makeDir(dir_name)
+# script_tools.makeDir(dir_name)
 
 import os
-from colorama import Fore, Back, Style, init
 
 # creates directory if it does not exist
 def makeDir(dir_name):

--- a/scripts/script_tools.py
+++ b/scripts/script_tools.py
@@ -16,6 +16,13 @@ def makeDir(dir_name):
     if not os.path.exists(dir_name):
         os.makedirs(dir_name)
 
+# determine if a group contains and element
+def group_contains_element(group, element):
+    if element in group:
+        return True
+    else:
+        return False
+
 # get adapter board channel
 def getAdapterBoardChannel(cable_type, channel):
     channel_map = {
@@ -28,17 +35,3 @@ def getAdapterBoardChannel(cable_type, channel):
         return channel_map[channel]
     else:
         return channel 
-
-# determine if cable type is valid
-def is_valid_cable_type(cable_types, cable_type):
-    if cable_type in cable_types:
-        return True
-    else:
-        return False
-    
-# determine if branch is valid
-def is_valid_branch(branches, branch):
-    if branch in branches:
-        return True
-    else:
-        return False

--- a/scripts/script_tools.py
+++ b/scripts/script_tools.py
@@ -1,0 +1,44 @@
+# script_tools.py
+
+# This is a place for utility functions (tools).
+
+# To use these functions in another file, add this import statement:
+# import tools
+
+# Then, call functions as needed, for example:
+# tools.makeDir(dir_name)
+
+import os
+from colorama import Fore, Back, Style, init
+
+# creates directory if it does not exist
+def makeDir(dir_name):
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+
+# get adapter board channel
+def getAdapterBoardChannel(cable_type, channel):
+    channel_map = {
+                "cmd" : "cmd", 
+                "d2" : "d1",
+                "d1" : "d2",
+                "d0" : "d3"
+    }
+    if cable_type == "2p3" or cable_type == "1p3":
+        return channel_map[channel]
+    else:
+        return channel 
+
+# determine if cable type is valid
+def is_valid_cable_type(cable_types, cable_type):
+    if cable_type in cable_types:
+        return True
+    else:
+        return False
+    
+# determine if branch is valid
+def is_valid_branch(branches, branch):
+    if branch in branches:
+        return True
+    else:
+        return False

--- a/scripts/script_tools.py
+++ b/scripts/script_tools.py
@@ -23,6 +23,11 @@ def group_contains_element(group, element):
     else:
         return False
 
+# print line of a specified length
+def printLine(length):
+    line = "-" * length
+    print(line)
+
 # Process input wiring type to support these formats:
 # inputs: 2.3, 2p3, 2P3
 # output: 2.3

--- a/scripts/script_tools.py
+++ b/scripts/script_tools.py
@@ -28,6 +28,16 @@ def printLine(length):
     line = "-" * length
     print(line)
 
+# convert mm to ft
+def convert_mm_to_ft(value_mm):
+    value_ft = value_mm / 304.8
+    return value_ft
+
+# convert ft to mm
+def convert_ft_to_mm(value_ft):
+    value_mm = value_ft * 304.8
+    return value_mm
+
 # Process input wiring type to support these formats:
 # inputs: 2.3, 2p3, 2P3
 # output: 2.3

--- a/scripts/script_tools.py
+++ b/scripts/script_tools.py
@@ -23,6 +23,30 @@ def group_contains_element(group, element):
     else:
         return False
 
+# Process input wiring type to support these formats:
+# inputs: 2.3, 2p3, 2P3
+# output: 2.3
+def formatWiringType(wiring_type):
+    # - Remove leading and ending whitespace using strip().
+    # - Convert to lowercase.
+    # - Replace "p" with ".".
+    wiring_type = wiring_type.strip()
+    wiring_type = wiring_type.lower()
+    wiring_type = wiring_type.replace("p", ".")
+    return wiring_type
+
+# Process input length type to support these formats:
+# inputs: R1_G1, r1_g1, R1 G1, r1 g1
+# output: R1_G1
+def formatLengthType(length_type):
+    # - Remove leading and ending whitespace using strip().
+    # - Convert to uppercase.
+    # - Replace " " with "_".
+    length_type = length_type.strip()
+    length_type = length_type.upper()
+    length_type = length_type.replace(" ", "_")
+    return length_type
+
 # get adapter board channel
 def getAdapterBoardChannel(cable_type, channel):
     channel_map = {

--- a/scripts/wire_length.py
+++ b/scripts/wire_length.py
@@ -1,4 +1,4 @@
-# calc_length.py
+# wire_length.py
 #
 # Developed by the KU CMS group.
 #
@@ -179,6 +179,7 @@ def run():
     # calculate new wire log
     new_wire_log = prev_wire_log - wire_length_batch_ft
 
+    # print results
     print(Fore.GREEN + f"Wire length for 1 e-link: " + Fore.RESET)
     print(f"\t{wire_length_elink_mm:.1f} mm = {wire_length_elink_ft:.1f} ft")
     print(Fore.GREEN + f"Wire length for {n_elinks} e-links: " + Fore.RESET)


### PR DESCRIPTION
Wire Length Calculator: new script to calculate wire length.
- Computes the total wire length for 1 e-link and n e-links based on user input.
- Checks for valid e-link wiring type and full type (wiring + length).
- Includes loss per twisted pair (specified by user).
- Computes updated wire log entry.

User inputs:
- e-link wiring type
- e-link length type
- loss per twisted pair (mm)
- number of e-links
- previous wire log entry (ft)

Output:
- wire length of 1 e-link (mm and ft)
- wire length of n e-links (mm and ft)
- new wire log entry (ft)