### PR TITLE
Wire Length Calculator Updates

### DIFF
--- a/scripts/WireLengthCalculator.py
+++ b/scripts/WireLengthCalculator.py
@@ -5,17 +5,23 @@
 # -------------------------- #
 # Wire Length Calculator
 # Author:   Caleb Smith
-# Date:     October 22, 2024
+# Date:     October 23, 2024
 # -------------------------- #
 
+import script_tools
+from colorama import Fore, Back, Style, init
+
+# Wire Length Calculator
 class WireLengthCalculator:
-    def __init__(self, wiring_type, length_type, loss):
+    def __init__(self, wiring_type, length_type, loss, line_length):
         self.wiring_type    = wiring_type
         self.length_type    = length_type
         self.loss           = loss
+        self.line_length    = line_length
         # set up cable info
         self.SetupCableInfo()
-
+    
+    # set up cable info
     def SetupCableInfo(self):
         # cable branches based on wiring type
         self.cable_branches = {
@@ -58,4 +64,60 @@ class WireLengthCalculator:
 
         # supported full types (wiring + length)
         self.full_types = list(self.cable_lengths.keys())
+
+    # calculate wire length for one e-link
+    def CalcWireLengthElink(self):
+        wire_length_elink = -1
+        full_type = ""
+        branches = []
+        branch_lengths = {}
+        
+        # check if wiring type is valid
+        wiring_type_is_valid = script_tools.group_contains_element(self.wiring_types, self.wiring_type)
+        if wiring_type_is_valid:
+            # assign branches
+            branches = self.cable_branches[self.wiring_type]
+        else:
+            # print error messages and return
+            print(Fore.RED + f"ERROR: {self.wiring_type} is not a valid wiring type." + Fore.RESET)
+            print(Fore.RED + f"Please enter a valid wiring type from this list:" + Fore.RESET)
+            print(Fore.RED + f"{self.wiring_types}" + Fore.RESET)
+            return wire_length_elink
+        
+        # get full type (wiring + length)
+        full_type = "{0} {1}".format(self.wiring_type, self.length_type)
+        
+        # check if full type (wiring + length) is valid
+        full_type_is_valid = script_tools.group_contains_element(self.full_types, full_type)
+        if full_type_is_valid:
+            # assign branch lengths
+            branch_lengths = self.cable_lengths[full_type]
+        else:
+            # print error messages and return
+            print(Fore.RED + f"ERROR: {full_type} is not a valid e-link type (defined by wiring and length)." + Fore.RESET)
+            print(Fore.RED + f"Please enter a valid combination of e-link wiring and length types from this list:" + Fore.RESET)
+            print(Fore.RED + f"{self.full_types}" + Fore.RESET)
+            return wire_length_elink
+        
+        # get number of channels per branch
+        n_channels_per_branch = self.cable_channels_per_branch[self.wiring_type]
+        
+        print(f" - full_type: {full_type}")
+        print(f" - branches: {branches}")
+        print(f" - n_channels_per_branch: {n_channels_per_branch}")
+        print(f" - branch_lengths: {branch_lengths}")
+        script_tools.printLine(self.line_length)
+
+        # calculate wire length for one e-link
+        wire_length_elink = 0
+        for branch in branches:
+            branch_length = branch_lengths[branch]
+            length_to_add = n_channels_per_branch * (branch_length + self.loss)
+            wire_length_elink += length_to_add
+        return wire_length_elink
+
+    # calculate wire length for a batch of n e-links
+    def CalcWireLengthBatch(self, n_elinks, wire_length_elink):
+        wire_length_batch = n_elinks * wire_length_elink
+        return wire_length_batch
 

--- a/scripts/WireLengthCalculator.py
+++ b/scripts/WireLengthCalculator.py
@@ -1,0 +1,61 @@
+# WireLengthCalculator.py
+#
+# Developed by the KU CMS group.
+#
+# -------------------------- #
+# Wire Length Calculator
+# Author:   Caleb Smith
+# Date:     October 22, 2024
+# -------------------------- #
+
+class WireLengthCalculator:
+    def __init__(self, wiring_type, length_type, loss):
+        self.wiring_type    = wiring_type
+        self.length_type    = length_type
+        self.loss           = loss
+        # set up cable info
+        self.SetupCableInfo()
+
+    def SetupCableInfo(self):
+        # cable branches based on wiring type
+        self.cable_branches = {
+            "3.2" : ["A", "B", "C"],
+            "2.2" : ["A", "C"],
+            "2.3" : ["A", "B"],
+            "1.3" : ["A"]
+        }
+
+        # number of channels per branch based on wiring type
+        self.cable_channels_per_branch = {
+            "3.2" : 3,
+            "2.2" : 3,
+            "2.3" : 4,
+            "1.3" : 4
+        }
+
+        # cable lengths (mm) from Design B (Axel Filenius, March 1, 2024)
+        self.cable_lengths = {
+            # Ring 1 (R1)
+            "2.3 R1_G1" : {"A" : 280, "B" : 280},
+            "2.3 R1_G2" : {"A" : 275, "B" : 330},
+            "1.3 R1_G3" : {"A" : 390},
+            # Ring 2 (R2)
+            "2.3 R2_G1" : {"A" : 200, "B" : 240},
+            "2.3 R2_G2" : {"A" : 275, "B" : 330},
+            "2.3 R2_G3" : {"A" : 275, "B" : 330},
+            "2.3 R2_G4" : {"A" : 337, "B" : 377},
+            # Ring 3 (R3)
+            "3.2 R3_G1" : {"A" : 200, "B" : 215, "C": 310},
+            "3.2 R3_G2" : {"A" : 365, "B" : 435, "C": 510},
+            # Ring 4 (R4)
+            "3.2 R4_G1" : {"A" : 190, "B" : 200, "C": 235},
+            "3.2 R4_G2" : {"A" : 230, "B" : 275, "C": 315},
+            "2.2 R4_G3" : {"A" : 360, "C" : 405},
+        }
+
+        # supported wiring types
+        self.wiring_types = list(self.cable_branches.keys())
+
+        # supported full types (wiring + length)
+        self.full_types = list(self.cable_lengths.keys())
+

--- a/scripts/test_colors.py
+++ b/scripts/test_colors.py
@@ -1,25 +1,37 @@
 # test_colors.py
-
+#
 # Colorama:
 # https://pypi.org/project/colorama/
-
+#
 # Warning:
 #
 # By default, colors will not work in Windows Command Prompt;
 # you will only get ANSI escape codes.
 #
-# To fix this, you need to use this line:
+# For Windows, use this line:
 # init(convert=True)
+#
+# For other operating systems (platforms), use this line:
+# init(convert=False)
 #
 # Fix colors for Windows Command Prompt:
 # https://stackoverflow.com/questions/9848889/colorama-for-python-not-returning-colored-print-lines-on-windows
+#
 
 from colorama import Fore, Back, Style, init
+import sys
 
-# Fixes colors for Windows Command Prompt:
-init(convert=True)
+# Check operating system (platform)
+if sys.platform == "win32":
+    # For Windows Command Prompt, fix colors using convert=True:
+    init(convert=True)
+else:
+    # For other OS/platforms, use convert=False:
+    init(convert=False)
 
+# test colors
 def test_colors():
+    print(f"Operating System (platform): {sys.platform}")
     print("Testing colors...")
     print("1 - " + Fore.BLACK    + "BLACK"    + Fore.RESET)
     print("2 - " + Fore.RED      + "RED"      + Fore.RESET)

--- a/scripts/wire_length.py
+++ b/scripts/wire_length.py
@@ -24,7 +24,6 @@
 # - New wire log entry.
 #
 # TODO:
-# - Customize the "fix color" init() command based on the operating system.
 #
 # DONE:
 # - Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
@@ -36,30 +35,38 @@
 # - Print the new wire log value in feet (after subtracting used wire)
 # - Hardcode estimated loss per twisted pair (mm)
 # - Create WireLengthCalculator class in a different file
-
-# version
-version = 2.0
+# - Customize the "fix color" init() command based on the operating system.
 
 from WireLengthCalculator import WireLengthCalculator
 import script_tools
 from colorama import Fore, Back, Style, init
+import sys
 
-# Fixes colors for Windows Command Prompt:
-init(convert=True)
-
-# specify length of line for printing
-line_length = 50
+# Check operating system (platform)
+if sys.platform == "win32":
+    # For Windows Command Prompt, fix colors using convert=True:
+    init(convert=True)
+else:
+    # For other OS/platforms, use convert=False:
+    init(convert=False)
 
 # run wire length calculator
 def run():
+    # version
+    version = 2.0
+
+    # specify length of line for printing
+    line_length = 50
+
+    # hardcode estimated loss per twisted pair (mm)
+    loss = 128
+
     script_tools.printLine(line_length)
     print(Fore.GREEN + f"Wire Length Calculator (version {version})" + Fore.RESET)
+    print(Fore.GREEN + f"Operating System (platform): {sys.platform}" + Fore.RESET)
     print(Fore.GREEN + "Calculating twisted pair wire length." + Fore.RESET)
     script_tools.printLine(line_length)
 
-    # Hardcode estimated loss per twisted pair (mm)
-    loss = 128
-    
     # User input
     wiring_type     = input(Fore.GREEN + "Enter e-link wiring type: " + Fore.RESET)
     length_type     = input(Fore.GREEN + "Enter e-link length type: " + Fore.RESET)

--- a/scripts/wire_length.py
+++ b/scripts/wire_length.py
@@ -2,14 +2,14 @@
 #
 # Developed by the KU CMS group.
 #
-# ---------------------- #
+# -------------------------- #
 # Wire Length Calculator
 # Author:   Caleb Smith
-# Date:     October 21, 2024
-# ---------------------- #
+# Date:     October 23, 2024
+# -------------------------- #
 #
 # Computes the total wire length for 1 e-link and n e-links based on user input.
-# Also computes updated wire log.
+# Also computes new wire log entry.
 #
 # The user must input the following information:
 # - e-link wiring type
@@ -18,8 +18,13 @@
 # - number of e-links
 # - previous wire log (ft)
 #
+# Output:
+# - Wire length for 1 e-link.
+# - Wire length for n e-links.
+# - New wire log entry.
+#
 # TODO:
-# - Create LengthCalculator or WireLengthCalculator class in a different file
+# - Customize the "fix color" init() command based on the operating system.
 #
 # DONE:
 # - Process input wiring type to support these formats: 3.2, 3p2, and 3P2.
@@ -30,10 +35,12 @@
 # - Ask user for previous wire log value in feet (remaining length of wire in spool)
 # - Print the new wire log value in feet (after subtracting used wire)
 # - Hardcode estimated loss per twisted pair (mm)
+# - Create WireLengthCalculator class in a different file
 
 # version
-version = 1.1
+version = 2.0
 
+from WireLengthCalculator import WireLengthCalculator
 import script_tools
 from colorama import Fore, Back, Style, init
 
@@ -42,104 +49,6 @@ init(convert=True)
 
 # specify length of line for printing
 line_length = 50
-
-# cable branches based on wiring type
-cable_branches = {
-    "3.2" : ["A", "B", "C"],
-    "2.2" : ["A", "C"],
-    "2.3" : ["A", "B"],
-    "1.3" : ["A"]
-}
-
-# number of channels per branch based on wiring type
-cable_channels_per_branch = {
-    "3.2" : 3,
-    "2.2" : 3,
-    "2.3" : 4,
-    "1.3" : 4
-}
-
-# cable lengths (mm) from Design B (Axel Filenius, March 1, 2024)
-cable_lengths = {
-    # Ring 1 (R1)
-    "2.3 R1_G1" : {"A" : 280, "B" : 280},
-    "2.3 R1_G2" : {"A" : 275, "B" : 330},
-    "1.3 R1_G3" : {"A" : 390},
-    # Ring 2 (R2)
-    "2.3 R2_G1" : {"A" : 200, "B" : 240},
-    "2.3 R2_G2" : {"A" : 275, "B" : 330},
-    "2.3 R2_G3" : {"A" : 275, "B" : 330},
-    "2.3 R2_G4" : {"A" : 337, "B" : 377},
-    # Ring 3 (R3)
-    "3.2 R3_G1" : {"A" : 200, "B" : 215, "C": 310},
-    "3.2 R3_G2" : {"A" : 365, "B" : 435, "C": 510},
-    # Ring 4 (R4)
-    "3.2 R4_G1" : {"A" : 190, "B" : 200, "C": 235},
-    "3.2 R4_G2" : {"A" : 230, "B" : 275, "C": 315},
-    "2.2 R4_G3" : {"A" : 360, "C" : 405},
-}
-
-# supported wiring types
-wiring_types = list(cable_branches.keys())
-
-# supported full types (wiring + length)
-full_types = list(cable_lengths.keys())
-
-# calculate wire length for one e-link
-def CalcWireLengthElink(wiring_type, length_type, loss):
-    wire_length_elink = -1
-    full_type = ""
-    branches = []
-    branch_lengths = {}
-    
-    # check if wiring type is valid
-    wiring_type_is_valid = script_tools.group_contains_element(wiring_types, wiring_type)
-    if wiring_type_is_valid:
-        # assign branches
-        branches = cable_branches[wiring_type]
-    else:
-        # print error messages and return
-        print(Fore.RED + f"ERROR: {wiring_type} is not a valid wiring type." + Fore.RESET)
-        print(Fore.RED + f"Please enter a valid wiring type from this list:" + Fore.RESET)
-        print(Fore.RED + f"{wiring_types}" + Fore.RESET)
-        return wire_length_elink
-    
-    # get full type (wiring + length)
-    full_type = "{0} {1}".format(wiring_type, length_type)
-    
-    # check if full type (wiring + length) is valid
-    full_type_is_valid = script_tools.group_contains_element(full_types, full_type)
-    if full_type_is_valid:
-        # assign branch lengths
-        branch_lengths = cable_lengths[full_type]
-    else:
-        # print error messages and return
-        print(Fore.RED + f"ERROR: {full_type} is not a valid e-link type (defined by wiring and length)." + Fore.RESET)
-        print(Fore.RED + f"Please enter a valid combination of e-link wiring and length types from this list:" + Fore.RESET)
-        print(Fore.RED + f"{full_types}" + Fore.RESET)
-        return wire_length_elink
-    
-    # get number of channels per branch
-    n_channels_per_branch = cable_channels_per_branch[wiring_type]
-    
-    print(f" - full_type: {full_type}")
-    print(f" - branches: {branches}")
-    print(f" - n_channels_per_branch: {n_channels_per_branch}")
-    print(f" - branch_lengths: {branch_lengths}")
-    script_tools.printLine(line_length)
-
-    # calculate wire length for one e-link
-    wire_length_elink = 0
-    for branch in branches:
-        branch_length = branch_lengths[branch]
-        length_to_add = n_channels_per_branch * (branch_length + loss)
-        wire_length_elink += length_to_add
-    return wire_length_elink
-
-# calculate wire length for a batch of n e-links
-def CalcWireLengthBatch(n_elinks, wire_length_elink):
-    wire_length_batch = n_elinks * wire_length_elink
-    return wire_length_batch
 
 # run wire length calculator
 def run():
@@ -176,8 +85,11 @@ def run():
     # Split into two steps (1 e-link and n e-links)
     # so that we can print out both.
 
+    # initialize calculator
+    calculator = WireLengthCalculator(wiring_type, length_type, loss, line_length)
+
     # calculate wire length for one e-link
-    wire_length_elink_mm = CalcWireLengthElink(wiring_type, length_type, loss)
+    wire_length_elink_mm = calculator.CalcWireLengthElink()
     wire_length_elink_ft = script_tools.convert_mm_to_ft(wire_length_elink_mm)
 
     # if length < 0 (invalid), return
@@ -185,7 +97,7 @@ def run():
         return
 
     # calculate wire length for a batch of n e-links
-    wire_length_batch_mm = CalcWireLengthBatch(n_elinks, wire_length_elink_mm)
+    wire_length_batch_mm = calculator.CalcWireLengthBatch(n_elinks, wire_length_elink_mm)
     wire_length_batch_ft = script_tools.convert_mm_to_ft(wire_length_batch_mm)
 
     # calculate new wire log


### PR DESCRIPTION
Wire Length Calculator Updates
- Create and use WireLengthCalculator class
- Customize colorama init(convert) based on operating system to fix color issue (see solution [here](https://stackoverflow.com/questions/9848889/colorama-for-python-not-returning-colored-print-lines-on-windows))

Tested and working on macOS Sonoma 14.6.1, AlmaLinux 9.4, Windows 10, and Windows 11.
