### PR TITLE
Backup and collect e-link testing results

### DIFF
--- a/scripts/backupAndCollectResults.sh
+++ b/scripts/backupAndCollectResults.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# backupAndCollectResults.sh
+#
+# Developed by the KU CMS group.
+#
+# -------------------------- #
+# Author:   Caleb Smith
+# Date:     January 12, 2025
+# -------------------------- #
+
+# Backup results
+./backupResults.sh
+
+# Collect results
+./collectResults.sh
+

--- a/scripts/backupResults.sh
+++ b/scripts/backupResults.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# backupResults.sh
+#
+# Developed by the KU CMS group.
+#
+# -------------------------- #
+# Author:   Caleb Smith
+# Date:     January 12, 2025
+# -------------------------- #
+
+VPN_URL=kuanywhere.ku.edu
+SERVER_PATH=smb://resfs.home.ku.edu/GROUPS/PHSX/General/BEAN_GRP
+RESULTS_DIR=/Volumes/BEAN_GRP/EyeBERTAutomation/automation_results
+BACKUP_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation
+
+# Confirm access to the results stored on the R drive.
+if [ ! -d "$RESULTS_DIR" ];
+then
+    echo "ERROR: Cannot access the results directory on the R drive: ${RESULTS_DIR}"
+    echo "Please connect to the R drive using this path: ${SERVER_PATH}"
+    echo "You need to be connected to the JAYHAWK network, either from campus or using a VPN client."
+    echo "You can get a KU VPN using Cisco Secure Client with this URL: ${VPN_URL}"
+    exit 1
+fi
+
+# Backup results.
+echo "Backing up results..."
+echo " - source (R drive): ${RESULTS_DIR}"
+echo " - destination (local): ${BACKUP_DIR}"
+
+mkdir -p $BACKUP_DIR
+rsync -az $RESULTS_DIR $BACKUP_DIR
+
+echo "Finished backing up results."
+

--- a/scripts/backupResults.sh
+++ b/scripts/backupResults.sh
@@ -32,5 +32,5 @@ echo " - destination (local): ${BACKUP_DIR}"
 mkdir -p $BACKUP_DIR
 rsync -az $RESULTS_DIR $BACKUP_DIR
 
-echo "Finished backing up results."
+echo "Finished backing up results!"
 

--- a/scripts/backupResults.sh
+++ b/scripts/backupResults.sh
@@ -9,10 +9,17 @@
 # Date:     January 12, 2025
 # -------------------------- #
 
-VPN_URL=kuanywhere.ku.edu
-SERVER_PATH=smb://resfs.home.ku.edu/GROUPS/PHSX/General/BEAN_GRP
-RESULTS_DIR=/Volumes/BEAN_GRP/EyeBERTAutomation/automation_results
+# Results paths (remote)
+RESULTS_DIR=/Volumes/BEAN_GRP/EyeBERTAutomation
+RESULTS_PLOTS_DIR=$RESULTS_DIR/automation_results
+
+# Backup paths (local)
 BACKUP_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation
+BACKUP_DATA_DIR=$BACKUP_DIR/automation_data
+
+# Network paths
+SERVER_PATH=smb://resfs.home.ku.edu/GROUPS/PHSX/General/BEAN_GRP
+VPN_URL=kuanywhere.ku.edu
 
 # Confirm access to the results stored on the R drive.
 if [ ! -d "$RESULTS_DIR" ];
@@ -24,13 +31,23 @@ then
     exit 1
 fi
 
-# Backup results.
-echo "Backing up results..."
-echo " - source (R drive): ${RESULTS_DIR}"
+# Create backup directories
+mkdir -p $BACKUP_DIR
+mkdir -p $BACKUP_DATA_DIR
+
+# Backup data
+echo "Backing up data..."
+echo " - source (R drive): ${RESULTS_DIR}/*.xlsx"
+echo " - destination (local): ${BACKUP_DATA_DIR}"
+
+rsync -az $RESULTS_DIR/*.xlsx $BACKUP_DATA_DIR
+
+# Backup plots
+echo "Backing up plots..."
+echo " - source (R drive): ${RESULTS_PLOTS_DIR}"
 echo " - destination (local): ${BACKUP_DIR}"
 
-mkdir -p $BACKUP_DIR
-rsync -az $RESULTS_DIR $BACKUP_DIR
+rsync -az $RESULTS_PLOTS_DIR $BACKUP_DIR
 
 echo "Finished backing up results!"
 

--- a/scripts/collectResults.sh
+++ b/scripts/collectResults.sh
@@ -4,7 +4,7 @@ VPN_URL=kuanywhere.ku.edu
 SERVER_PATH=smb://resfs.home.ku.edu/GROUPS/PHSX/General/BEAN_GRP
 RESULTS_DIR=/Volumes/BEAN_GRP/EyeBERTAutomation/automation_results
 BACKUP_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation
-#TARGET_DIR=
+TARGET_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation/results_for_database
 
 # Confirm access to the results stored on the R drive.
 if [ ! -d "$RESULTS_DIR" ];
@@ -21,7 +21,12 @@ echo "Backing up results..."
 echo " - source (R drive): ${RESULTS_DIR}"
 echo " - destination (local): ${BACKUP_DIR}"
 mkdir -p $BACKUP_DIR
-rsync -az $RESULTS_DIR $BACKUP_DIR
+#rsync -az $RESULTS_DIR $BACKUP_DIR
+
+# Copy results.
+python3.10 getElinkResults.py -s $RESULTS_DIR -t $TARGET_DIR
+
+# Create tarball.
 
 echo "Done!"
 

--- a/scripts/collectResults.sh
+++ b/scripts/collectResults.sh
@@ -42,7 +42,13 @@ python3.10 getElinkResults.py -s $RESULTS_DIR -t $TARGET_DIR
 echo "Creating tarball..."
 
 # Find newest directory:
-NEWEST_DIR=$(ls -td ${TARGET_DIR}/* | head -1)
+# See https://stackoverflow.com/questions/9275964/get-the-newest-directory-to-a-variable-in-bash
+NEWEST_DIR=$(ls -td ${TARGET_DIR}/*/ | head -1)
+
+# Remove "/" from the end:
+# See https://unix.stackexchange.com/questions/144298/delete-the-last-character-of-a-string-using-string-manipulation-in-shell-script
+NEWEST_DIR=${NEWEST_DIR::-1}
+
 echo "Found this newest directory to use for tarball:" 
 echo "${NEWEST_DIR}"
 

--- a/scripts/collectResults.sh
+++ b/scripts/collectResults.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+#
+# collectResults.sh
+#
+# Developed by the KU CMS group.
+#
+# -------------------------- #
+# Author:   Caleb Smith
+# Date:     January 10, 2025
+# -------------------------- #
 
 VPN_URL=kuanywhere.ku.edu
 SERVER_PATH=smb://resfs.home.ku.edu/GROUPS/PHSX/General/BEAN_GRP
@@ -16,6 +25,8 @@ then
     exit 1
 fi
 
+echo "Collecting e-link results."
+
 # Backup results.
 echo "Backing up results..."
 echo " - source (R drive): ${RESULTS_DIR}"
@@ -24,9 +35,20 @@ mkdir -p $BACKUP_DIR
 #rsync -az $RESULTS_DIR $BACKUP_DIR
 
 # Copy results.
+echo "Copying results..."
 python3.10 getElinkResults.py -s $RESULTS_DIR -t $TARGET_DIR
 
 # Create tarball.
+echo "Creating tarball..."
+
+# Find newest directory:
+NEWEST_DIR=$(ls -t ${TARGET_DIR} | tail -n 1)
+
+echo "Newest directory: ${NEWEST_DIR}"
+
+tar -czf ${TARGET_DIR}/${NEWEST_DIR}.tar.gz ${TARGET_DIR}/${NEWEST_DIR}
+
+echo "Created ${TARGET_DIR}/${NEWEST_DIR}.tar.gz"
 
 echo "Done!"
 

--- a/scripts/collectResults.sh
+++ b/scripts/collectResults.sh
@@ -21,19 +21,23 @@ python3.10 getElinkResults.py -s $SOURCE_DIR -t $TARGET_DIR
 # Create tarball.
 echo "Creating tarball..."
 
+echo "Going to target directory:"
+echo ${TARGET_DIR}
+cd ${TARGET_DIR}
+
+echo "Finding the newest directory in the target directory..."
+
 # Find newest directory:
 # See https://stackoverflow.com/questions/9275964/get-the-newest-directory-to-a-variable-in-bash
-NEWEST_DIR=$(ls -td ${TARGET_DIR}/*/ | head -1)
+NEWEST_DIR=$(ls -td ./*/ | head -1)
 
 # Remove "/" from the end:
 # See https://unix.stackexchange.com/questions/144298/delete-the-last-character-of-a-string-using-string-manipulation-in-shell-script
 NEWEST_DIR=${NEWEST_DIR::-1}
 
-echo "Found this newest directory to use for tarball:" 
-echo "${NEWEST_DIR}"
-
+echo "Creating a tarball of this directory: ${NEWEST_DIR}" 
 tar -czf ${NEWEST_DIR}.tar.gz ${NEWEST_DIR}
 echo "Created ${NEWEST_DIR}.tar.gz"
 
-echo "Finished collecting e-link results."
+echo "Finished collecting e-link results!"
 

--- a/scripts/collectResults.sh
+++ b/scripts/collectResults.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+VPN_URL=kuanywhere.ku.edu
+SERVER_PATH=smb://resfs.home.ku.edu/GROUPS/PHSX/General/BEAN_GRP
+RESULTS_DIR=/Volumes/BEAN_GRP/EyeBERTAutomation/automation_results
+BACKUP_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation
+#TARGET_DIR=
+
+# Confirm access to the results stored on the R drive.
+if [ ! -d "$RESULTS_DIR" ];
+then
+    echo "ERROR: Cannot access the results directory on the R drive: ${RESULTS_DIR}"
+    echo "Please connect to the R drive using this path: ${SERVER_PATH}"
+    echo "You need to be connected to the JAYHAWK network, either from campus or using a VPN client."
+    echo "You can get a KU VPN using Cisco Secure Client with this URL: ${VPN_URL}"
+    exit 1
+fi
+
+# Backup results.
+echo "Backing up results..."
+echo " - source (R drive): ${RESULTS_DIR}"
+echo " - destination (local): ${BACKUP_DIR}"
+mkdir -p $BACKUP_DIR
+rsync -az $RESULTS_DIR $BACKUP_DIR
+
+echo "Done!"
+

--- a/scripts/collectResults.sh
+++ b/scripts/collectResults.sh
@@ -42,13 +42,12 @@ python3.10 getElinkResults.py -s $RESULTS_DIR -t $TARGET_DIR
 echo "Creating tarball..."
 
 # Find newest directory:
-NEWEST_DIR=$(ls -t ${TARGET_DIR} | tail -n 1)
+NEWEST_DIR=$(ls -td ${TARGET_DIR}/* | head -1)
+echo "Found this newest directory to use for tarball:" 
+echo "${NEWEST_DIR}"
 
-echo "Newest directory: ${NEWEST_DIR}"
-
-tar -czf ${TARGET_DIR}/${NEWEST_DIR}.tar.gz ${TARGET_DIR}/${NEWEST_DIR}
-
-echo "Created ${TARGET_DIR}/${NEWEST_DIR}.tar.gz"
+tar -czf ${NEWEST_DIR}.tar.gz ${NEWEST_DIR}
+echo "Created ${NEWEST_DIR}.tar.gz"
 
 echo "Done!"
 

--- a/scripts/collectResults.sh
+++ b/scripts/collectResults.sh
@@ -9,34 +9,14 @@
 # Date:     January 10, 2025
 # -------------------------- #
 
-VPN_URL=kuanywhere.ku.edu
-SERVER_PATH=smb://resfs.home.ku.edu/GROUPS/PHSX/General/BEAN_GRP
-RESULTS_DIR=/Volumes/BEAN_GRP/EyeBERTAutomation/automation_results
-BACKUP_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation
+SOURCE_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation/automation_results
 TARGET_DIR=~/CMS/Tracker/e-links/EyeBERTAutomation/results_for_database
-
-# Confirm access to the results stored on the R drive.
-if [ ! -d "$RESULTS_DIR" ];
-then
-    echo "ERROR: Cannot access the results directory on the R drive: ${RESULTS_DIR}"
-    echo "Please connect to the R drive using this path: ${SERVER_PATH}"
-    echo "You need to be connected to the JAYHAWK network, either from campus or using a VPN client."
-    echo "You can get a KU VPN using Cisco Secure Client with this URL: ${VPN_URL}"
-    exit 1
-fi
 
 echo "Collecting e-link results."
 
-# Backup results.
-echo "Backing up results..."
-echo " - source (R drive): ${RESULTS_DIR}"
-echo " - destination (local): ${BACKUP_DIR}"
-mkdir -p $BACKUP_DIR
-#rsync -az $RESULTS_DIR $BACKUP_DIR
-
 # Copy results.
 echo "Copying results..."
-python3.10 getElinkResults.py -s $RESULTS_DIR -t $TARGET_DIR
+python3.10 getElinkResults.py -s $SOURCE_DIR -t $TARGET_DIR
 
 # Create tarball.
 echo "Creating tarball..."
@@ -55,5 +35,5 @@ echo "${NEWEST_DIR}"
 tar -czf ${NEWEST_DIR}.tar.gz ${NEWEST_DIR}
 echo "Created ${NEWEST_DIR}.tar.gz"
 
-echo "Done!"
+echo "Finished collecting e-link results."
 

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -16,12 +16,12 @@ import glob
 
 # TODO:
 # - Add date to output directory.
-# - Print e-link branches that were copied.
 
 # DONE:
 # - Print total number of e-links that had results copied.
 # - Print number of files copied for each e-link.
 # - Only copy files from the largest run number.
+# - Print e-link branches that were copied.
 
 def main():
     # Arguments
@@ -63,7 +63,6 @@ def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
     print("Copying results for e-links {0} to {1}.".format(min_elink_num, max_elink_num))
 
     elink_branches = ["A", "B", "C"]
-
     num_elinks_copied = 0
     for number in range(min_elink_num, max_elink_num + 1):
         elink_input_dir  = "{0}/{1}".format(source_dir, number)
@@ -71,8 +70,9 @@ def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
         
         if os.path.isdir(elink_input_dir):
             script_tools.makeDir(elink_output_dir)
+            
             num_files_per_elink = 0
-
+            branches_copied = []
             for branch in elink_branches:
                 latest_run = findLatestRunForBranch(elink_input_dir, number, branch)
                 
@@ -87,12 +87,13 @@ def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
                 file_list = glob.glob(pattern)
                 num_files_per_branch = len(file_list)
                 num_files_per_elink += num_files_per_branch
-                
+                branches_copied.append(branch)
+
                 for file in file_list:
                     #print(file)
                     shutil.copy(file, elink_output_dir)
             
-            print(" - e-link {0}: copied {1} files".format(number, num_files_per_elink))
+            print(" - e-link {0}: copied {1} files for branches {2}".format(number, num_files_per_elink, branches_copied))
             num_elinks_copied += 1
     
     print("Copied results for {0} e-links.".format(num_elinks_copied))

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -74,16 +74,12 @@ def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
             num_files_per_elink = 0
             branches_copied = []
             for branch in elink_branches:
-                latest_run = findLatestRunForBranch(elink_input_dir, number, branch)
-                
-                pattern = ""
-                if latest_run <= 0:
+                latest_run = findLatestRunForBranch(elink_input_dir, number, branch)                
+                pattern = getPattern(elink_input_dir, number, branch, latest_run)
+
+                if not pattern:
                     continue
-                elif latest_run == 1:
-                    pattern = "{0}/{1}_{2}_*.png".format(elink_input_dir, number, branch)
-                else:
-                    pattern = "{0}/{1}_{2}_*_{3}.png".format(elink_input_dir, number, branch, latest_run)
-                
+
                 file_list = glob.glob(pattern)
                 num_files_per_branch = len(file_list)
                 num_files_per_elink += num_files_per_branch
@@ -114,6 +110,17 @@ def findLatestRunForBranch(directory, elink_number, elink_branch):
         file_path = "{0}/{1}_{2}_{3}_{4}.png".format(directory, elink_number, elink_branch, elink_channel, run)
 
     return result
+
+def getPattern(directory, elink_number, elink_branch, latest_run):
+    if latest_run <= 0:
+        pattern = ""
+        return pattern
+    elif latest_run == 1:
+        pattern = "{0}/{1}_{2}_*.png".format(directory, elink_number, elink_branch)
+        return pattern
+    else:
+        pattern = "{0}/{1}_{2}_*_{3}.png".format(directory, elink_number, elink_branch, latest_run)
+        return pattern
 
 if __name__ == "__main__":
     main()

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -16,6 +16,7 @@ import glob
 
 # TODO:
 # - Add date to output directory.
+# - Add ability to skip e-links (for e-links that already have plots in the database).
 
 # DONE:
 # - Print total number of e-links that had results copied.
@@ -55,7 +56,7 @@ def main():
     copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num)
 
 def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
-    output_dir = "{0}/results_elinks_{1}_to_{2}".format(target_dir, min_elink_num, max_elink_num)
+    output_dir = "{0}/EyeBERT_plots_elinks_{1}_to_{2}".format(target_dir, min_elink_num, max_elink_num)
     script_tools.makeDir(output_dir)
     
     print(" - Input directory:  {0}".format(source_dir))

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -16,31 +16,41 @@ import shutil
 import glob
 
 # TODO:
+# - Only copy files from the largest run number.
 # - Add date to output directory.
-# - Print number of files copied for each e-link
-# - Print total number of e-links that had results copied.
 
 # DONE:
+# - Print total number of e-links that had results copied.
+# - Print number of files copied for each e-link.
 
 def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
     output_dir = "{0}/results_elinks_{1}_to_{2}".format(target_dir, min_elink_num, max_elink_num)
     script_tools.makeDir(output_dir)
     
+    print("Input directory:  {0}".format(source_dir))
+    print("Output directory: {0}".format(output_dir))
     print("Copying results for e-links {0} to {1}.".format(min_elink_num, max_elink_num))
-    print(" - input directory:  {0}".format(source_dir))
-    print(" - output directory: {0}".format(output_dir))
 
+    num_elinks_copied = 0
     for number in range(min_elink_num, max_elink_num + 1):
         elink_input_dir  = "{0}/{1}".format(source_dir, number)
         elink_output_dir = "{0}/{1}".format(output_dir, number)
         
         if os.path.isdir(elink_input_dir):
-            print(" - e-link {0}".format(number))
             script_tools.makeDir(elink_output_dir)
+            
             pattern = "{0}/*.png".format(elink_input_dir)
-            for file in glob.glob(pattern):
+            file_list = glob.glob(pattern)
+            num_files = len(file_list)
+            
+            for file in file_list:
                 #print(file)
                 shutil.copy(file, elink_output_dir)
+            
+            print(" - e-link {0}: copied {1} files".format(number, num_files))
+            num_elinks_copied += 1
+    
+    print("Copied results for {0} e-links.".format(num_elinks_copied))
 
 def main():
     # Arguments

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -1,0 +1,37 @@
+# getElinkResults.py
+#
+# Developed by the KU CMS group.
+#
+# -------------------------- #
+# Get Elink Results
+# Author:   Caleb Smith
+# Date:     January 10, 2025
+# -------------------------- #
+
+import script_tools
+import sys
+
+def getElinkResults(min_elink_num, max_elink_num):
+    print("Getting results for e-links {0} to {1}.".format(min_elink_num, max_elink_num))
+    #target_dir = "results_elinks_{0}_to_{1}".format(min_elink_num, max_elink_num)
+    #makeDir(target_dir)
+    for number in range(min_elink_num, max_elink_num + 1):
+        print(" - Copying results for e-link {0}".format(number))
+
+def main():
+    # User input
+    print("Please enter a range of e-link numbers (min and max) to include:")
+    min_elink_num = int(input("Enter minimum e-link number: "))
+    max_elink_num = int(input("Enter maximum e-link number: "))
+
+    if min_elink_num > max_elink_num:
+        print("ERROR: Invalid range of e-link numbers: [{0}, {1}]".format(min_elink_num, max_elink_num))
+        print("The maximum e-link number must be greater than or equal to the minimum e-link number.")
+        print("Please try again.")
+        sys.exit(1) 
+    
+    getElinkResults(min_elink_num, max_elink_num)
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -3,7 +3,6 @@
 # Developed by the KU CMS group.
 #
 # -------------------------- #
-# Get Elink Results
 # Author:   Caleb Smith
 # Date:     January 10, 2025
 # -------------------------- #

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -9,17 +9,58 @@
 # -------------------------- #
 
 import script_tools
+import argparse
 import sys
+import os
+import shutil
+import glob
 
-def getElinkResults(min_elink_num, max_elink_num):
-    print("Getting results for e-links {0} to {1}.".format(min_elink_num, max_elink_num))
-    #target_dir = "results_elinks_{0}_to_{1}".format(min_elink_num, max_elink_num)
-    #makeDir(target_dir)
+# TODO:
+# - Add date to output directory.
+# - Print number of files copied for each e-link
+# - Print total number of e-links that had results copied.
+
+# DONE:
+
+def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
+    output_dir = "{0}/results_elinks_{1}_to_{2}".format(target_dir, min_elink_num, max_elink_num)
+    script_tools.makeDir(output_dir)
+    
+    print("Copying results for e-links {0} to {1}.".format(min_elink_num, max_elink_num))
+    print(" - input directory:  {0}".format(source_dir))
+    print(" - output directory: {0}".format(output_dir))
+
     for number in range(min_elink_num, max_elink_num + 1):
-        print(" - Copying results for e-link {0}".format(number))
+        elink_input_dir  = "{0}/{1}".format(source_dir, number)
+        elink_output_dir = "{0}/{1}".format(output_dir, number)
+        
+        if os.path.isdir(elink_input_dir):
+            print(" - e-link {0}".format(number))
+            script_tools.makeDir(elink_output_dir)
+            pattern = "{0}/*.png".format(elink_input_dir)
+            for file in glob.glob(pattern):
+                #print(file)
+                shutil.copy(file, elink_output_dir)
 
 def main():
-    # User input
+    # Arguments
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--source_dir", "-s", default="", help="Source directory")
+    parser.add_argument("--target_dir", "-t", default="", help="Target directory")
+    
+    options     = parser.parse_args()
+    source_dir  = options.source_dir
+    target_dir  = options.target_dir
+
+    if not source_dir:
+        print("Please provide a source directory using the -s option.")
+        sys.exit(1) 
+    
+    if not target_dir:
+        print("Please provide a target directory using the -t option.")
+        sys.exit(1) 
+
+    # Additional user input
     print("Please enter a range of e-link numbers (min and max) to include:")
     min_elink_num = int(input("Enter minimum e-link number: "))
     max_elink_num = int(input("Enter maximum e-link number: "))
@@ -30,7 +71,7 @@ def main():
         print("Please try again.")
         sys.exit(1) 
     
-    getElinkResults(min_elink_num, max_elink_num)
+    copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num)
 
 if __name__ == "__main__":
     main()

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -16,7 +16,6 @@ import glob
 from datetime import datetime
 
 # TODO:
-# - Add ability to skip e-links (for e-links that already have plots in the database).
 
 # DONE:
 # - Print total number of e-links that had results copied.
@@ -24,6 +23,7 @@ from datetime import datetime
 # - Only copy files from the largest run number.
 # - Print e-link branches that were copied.
 # - Add date to output directory.
+# - Add ability to skip e-links (for e-links that already have plots in the database).
 
 def main():
     # Arguments
@@ -65,9 +65,19 @@ def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
     print(" - Output directory: {0}".format(output_dir))
     print("Copying results for e-links {0} to {1}.".format(min_elink_num, max_elink_num))
 
+    # list of e-links to skip (already have plots in the database)
+    elinks_to_skip = [904, 958, 988]
+    print("elinks_to_skip: {0}".format(elinks_to_skip))
+    
     elink_branches = ["A", "B", "C"]
     num_elinks_copied = 0
+    
     for number in range(min_elink_num, max_elink_num + 1):
+        
+        if number in elinks_to_skip:
+            print(" - Skipping e-link {0}".format(number))
+            continue
+        
         elink_input_dir  = "{0}/{1}".format(source_dir, number)
         elink_output_dir = "{0}/{1}".format(output_dir, number)
         

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -26,8 +26,8 @@ def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
     output_dir = "{0}/results_elinks_{1}_to_{2}".format(target_dir, min_elink_num, max_elink_num)
     script_tools.makeDir(output_dir)
     
-    print("Input directory:  {0}".format(source_dir))
-    print("Output directory: {0}".format(output_dir))
+    print(" - Input directory:  {0}".format(source_dir))
+    print(" - Output directory: {0}".format(output_dir))
     print("Copying results for e-links {0} to {1}.".format(min_elink_num, max_elink_num))
 
     num_elinks_copied = 0
@@ -71,8 +71,8 @@ def main():
 
     # Additional user input
     print("Please enter a range of e-link numbers (min and max) to include:")
-    min_elink_num = int(input("Enter minimum e-link number: "))
-    max_elink_num = int(input("Enter maximum e-link number: "))
+    min_elink_num = int(input(" - Enter minimum e-link number: "))
+    max_elink_num = int(input(" - Enter maximum e-link number: "))
 
     if min_elink_num > max_elink_num:
         print("ERROR: Invalid range of e-link numbers: [{0}, {1}]".format(min_elink_num, max_elink_num))

--- a/scripts/getElinkResults.py
+++ b/scripts/getElinkResults.py
@@ -13,9 +13,9 @@ import sys
 import os
 import shutil
 import glob
+from datetime import datetime
 
 # TODO:
-# - Add date to output directory.
 # - Add ability to skip e-links (for e-links that already have plots in the database).
 
 # DONE:
@@ -23,6 +23,7 @@ import glob
 # - Print number of files copied for each e-link.
 # - Only copy files from the largest run number.
 # - Print e-link branches that were copied.
+# - Add date to output directory.
 
 def main():
     # Arguments
@@ -56,7 +57,8 @@ def main():
     copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num)
 
 def copyElinkResults(source_dir, target_dir, min_elink_num, max_elink_num):
-    output_dir = "{0}/EyeBERT_plots_elinks_{1}_to_{2}".format(target_dir, min_elink_num, max_elink_num)
+    today = datetime.today().strftime("%Y_%m_%d")    
+    output_dir = "{0}/EyeBERT_plots_elinks_{1}_to_{2}_date_{3}".format(target_dir, min_elink_num, max_elink_num, today)
     script_tools.makeDir(output_dir)
     
     print(" - Input directory:  {0}".format(source_dir))


### PR DESCRIPTION
Backup and collect e-link testing results
- New bash script to backup e-link results (data and plots)
- New bash script to collect and tar e-link results (plots)
- New python script to collect e-link results (plots)

Features:
- Collects EyeBERT plots for a given range of e-links.
- Copies only latest testing run for each e-link branch.
- Creates output directory and .tar.gz file with today's date.
- Print total number of e-links that had results copied.
- Print number of files and list of branches copied for each e-link.
- There is a list to specify e-links that should be skipped (for e-links that already have plots in the database).

Bug fixes:
- Fix bugs with finding the newest directory to tar.
- Fix bugs with including full path in tar.
